### PR TITLE
Problem with token removal

### DIFF
--- a/javascripts/jquery.token-field.js
+++ b/javascripts/jquery.token-field.js
@@ -84,7 +84,7 @@
                 if (!settings.nested) {
                   var input = $(this).closest('.token-field').find('input:hidden');
                   var values = input.val().split(',');
-                  values.splice(0, 0, $(this).val());
+                  values.splice(values.length-1, 0, $(this).val());
                   input.val(values.join(','));
                 }
                 $(this).val('');


### PR DESCRIPTION
Hey, 

I found a potential bug in the js. If you tried to remove the token (by clicking on 'x' or by using 'backspace') wrong token was removed from hidden input value (on jQuery v1.4.2).

Check and if you agree pull the changes.

Thanks for the great plugin,
Bartek
