### PR TITLE
Please review the value of hidden input.

### DIFF
--- a/javascripts/jquery.token-field.js
+++ b/javascripts/jquery.token-field.js
@@ -85,6 +85,7 @@
                   var input = $(this).closest('.token-field').find('input:hidden');
                   var values = input.val().split(',');
                   values.splice(0, 0, $(this).val());
+                  values.pop();
                   input.val(values.join(','));
                 }
                 $(this).val('');


### PR DESCRIPTION
Last comma from hidden field value dissapear, because of split or explode functions in backend scripts.
